### PR TITLE
Deduce this

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project(stl-concepts VERSION 0.0.0 LANGUAGES CXX)
 
 enable_testing()
 
-set(CMAKE_CXX_STANDARD 20)
-
 set(TARGETS_EXPORT_NAME ${CMAKE_PROJECT_NAME}Targets)
 
 add_subdirectory(extern)

--- a/etc/clang-18-toolchain.cmake
+++ b/etc/clang-18-toolchain.cmake
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 23)
 
 set(CMAKE_CXX_FLAGS
   "-Wall -Wextra \
-   -stdlib=libstdc++ "
+   -stdlib=libc++ --gcc-toolchain=/home/sdowney/.local"
 CACHE STRING "CXX_FLAGS" FORCE)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3" CACHE STRING "C++ DEBUG Flags" FORCE)

--- a/etc/clang-18-toolchain.cmake
+++ b/etc/clang-18-toolchain.cmake
@@ -1,0 +1,17 @@
+include_guard(GLOBAL)
+
+set(CMAKE_C_COMPILER clang-18)
+set(CMAKE_CXX_COMPILER clang++-18)
+
+set(CMAKE_CXX_STANDARD 23)
+
+set(CMAKE_CXX_FLAGS
+  "-Wall -Wextra \
+   -stdlib=libstdc++ "
+CACHE STRING "CXX_FLAGS" FORCE)
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3" CACHE STRING "C++ DEBUG Flags" FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -g0 -DNDEBUG" CACHE STRING "C++ Release Flags" FORCE)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG" CACHE STRING "C++ RelWithDebInfo Flags" FORCE)
+set(CMAKE_CXX_FLAGS_TSAN "-O3 -g -DNDEBUG -fsanitize=thread" CACHE STRING "C++ TSAN Flags" FORCE)
+set(CMAKE_CXX_FLAGS_ASAN "-O3 -g -DNDEBUG -fsanitize=address -fsanitize=undefined -fsanitize=leak" CACHE STRING "C++ ASAN Flags" FORCE)

--- a/etc/gcc-14-toolchain.cmake
+++ b/etc/gcc-14-toolchain.cmake
@@ -1,0 +1,15 @@
+include_guard(GLOBAL)
+
+set(CMAKE_C_COMPILER gcc-14)
+set(CMAKE_CXX_COMPILER g++-14)
+
+set(CMAKE_CXX_FLAGS
+  "-std=c++23 \
+   -Wall -Wextra "
+CACHE STRING "CXX_FLAGS" FORCE)
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3" CACHE STRING "C++ DEBUG Flags" FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -g0 -DNDEBUG" CACHE STRING "C++ Release Flags" FORCE)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG" CACHE STRING "C++ RelWithDebInfo Flags" FORCE)
+set(CMAKE_CXX_FLAGS_TSAN "-O3 -g -DNDEBUG -fsanitize=thread" CACHE STRING "C++ TSAN Flags" FORCE)
+set(CMAKE_CXX_FLAGS_ASAN "-O3 -g -DNDEBUG -fsanitize=address -fsanitize=undefined -fsanitize=leak" CACHE STRING "C++ ASAN Flags" FORCE)

--- a/src/smd/views/maybe.h
+++ b/src/smd/views/maybe.h
@@ -9,9 +9,18 @@
 #include <type_traits>
 
 #include <smd/views/concepts.h>
+#include <smd/views/movable_box.h>
 
 namespace smd::views {
 namespace ranges = std::ranges;
+
+template <typename Value>
+class maybe_view;
+
+template <typename Value>
+inline constexpr bool is_maybe_view_v = false;
+template <typename Value>
+inline constexpr bool is_maybe_view_v<maybe_view<Value>> = true;
 
 template <typename Value>
 class maybe_view : public ranges::view_interface<maybe_view<Value>> {
@@ -39,7 +48,7 @@ class maybe_view : public ranges::view_interface<maybe_view<Value>> {
     constexpr Value* data() noexcept;
 
     constexpr const Value* data() const noexcept;
-    friend constexpr auto operator<=>(const maybe_view& lhs,
+    friend constexpr auto  operator<=>(const maybe_view& lhs,
                                       const maybe_view& rhs) {
         {
             return (lhs.value_ && rhs.value_)
@@ -53,34 +62,38 @@ class maybe_view : public ranges::view_interface<maybe_view<Value>> {
         return lhs.value_ == rhs.value_;
     }
 
-    template <typename F>
-    constexpr auto and_then(F&& f) &;
-    template <typename F>
-    constexpr auto and_then(F&& f) &&;
-    template <typename F>
-    constexpr auto and_then(F&& f) const&;
-    template <typename F>
-    constexpr auto and_then(F&& f) const&&;
+    template <typename Self, typename F>
+    constexpr auto and_then(this Self&& self, F&& f) {
+        using U =
+            std::invoke_result_t<F,
+                                 decltype(*std::forward<Self>(self).value_)>;
+        static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
+        if (self.value_) {
+            return std::invoke(std::forward<F>(f),
+                               *std::forward<Self>(self).value_);
+        } else {
+            return std::remove_cvref_t<U>();
+        }
+    }
 
-    template <typename F>
-    constexpr auto transform(F&& f) &;
-    template <typename F>
-    constexpr auto transform(F&& f) &&;
-    template <typename F>
-    constexpr auto transform(F&& f) const&;
-    template <typename F>
-    constexpr auto transform(F&& f) const&&;
+    template <typename Self, typename F>
+    constexpr auto transform(this Self&& self, F&& f) {
+        using U =
+            std::invoke_result_t<F,
+                                 decltype(*std::forward<Self>(self).value_)>;
+        return (self.value_)
+                   ? maybe_view<U>{std::invoke(
+                         std::forward<F>(f), *std::forward<Self>(self).value_)}
+                   : maybe_view<U>{};
+    }
 
-    template <typename F>
-    constexpr auto or_else(F&& f) &&;
-    template <typename F>
-    constexpr auto or_else(F&& f) const&;
+    template <typename Self, typename F>
+    constexpr auto or_else(this Self&& self, F&& f) {
+        using U = std::invoke_result_t<F>;
+        static_assert(std::is_same_v<std::remove_cvref_t<U>, maybe_view>);
+        return self.value_ ? std::forward<Self>(self) : std::forward<F>(f)();
+    }
 };
-
-template <typename Value>
-inline constexpr bool is_maybe_view_v = false;
-template <typename Value>
-inline constexpr bool is_maybe_view_v<maybe_view<Value>> = true;
 
 template <typename Value>
 constexpr maybe_view<Value>::maybe_view(const Value& value) : value_(value) {}
@@ -128,104 +141,6 @@ constexpr const Value* maybe_view<Value>::data() const noexcept {
 }
 
 template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::and_then(F&& f) & {
-    using U = std::invoke_result_t<F, Value&>;
-    static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
-    if (value_) {
-        return std::invoke(std::forward<F>(f), *value_);
-    } else {
-        return std::remove_cvref_t<U>();
-    }
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::and_then(F&& f) && {
-    using U = std::invoke_result_t<F, Value&&>;
-    static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
-    if (value_) {
-        return std::invoke(std::forward<F>(f), std::move(*value_));
-    } else {
-        return std::remove_cvref_t<U>();
-    }
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::and_then(F&& f) const& {
-    using U = std::invoke_result_t<F, const Value&>;
-    static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
-    if (value_) {
-        return std::invoke(std::forward<F>(f), *value_);
-    } else {
-        return std::remove_cvref_t<U>();
-    }
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::and_then(F&& f) const&& {
-    using U = std::invoke_result_t<F, const Value&&>;
-    static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
-    if (value_) {
-        return std::invoke(std::forward<F>(f), std::move(*value_));
-    } else {
-        return std::remove_cvref_t<U>();
-    }
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::transform(F&& f) & {
-    using U = std::invoke_result_t<F, Value&>;
-    return (value_) ? maybe_view<U>{std::invoke(std::forward<F>(f), *value_)}
-                    : maybe_view<U>{};
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::transform(F&& f) && {
-    using U = std::invoke_result_t<F, Value&&>;
-    return (value_) ? maybe_view<U>{std::invoke(std::forward<F>(f),
-                                                std::move(*value_))}
-                    : maybe_view<U>{};
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::transform(F&& f) const& {
-    using U = std::invoke_result_t<F, const Value&>;
-    return (value_) ? maybe_view<U>{std::invoke(std::forward<F>(f), *value_)}
-                    : maybe_view<U>{};
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::transform(F&& f) const&& {
-    using U = std::invoke_result_t<F, const Value&&>;
-    return (value_) ? maybe_view<U>{std::invoke(std::forward<F>(f),
-                                                std::move(*value_))}
-                    : maybe_view<U>{};
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::or_else(F&& f) const& {
-    using U = std::invoke_result_t<F>;
-    static_assert(std::is_same_v<std::remove_cvref_t<U>, maybe_view>);
-    return value_ ? *this : std::forward<F>(f)();
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value>::or_else(F&& f) && {
-    using U = std::invoke_result_t<F>;
-    static_assert(std::is_same_v<std::remove_cvref_t<U>, maybe_view>);
-    return value_ ? std::move(*this) : std::forward<F>(f)();
-}
-
-template <typename Value>
 class maybe_view<Value&> : public ranges::view_interface<maybe_view<Value&>> {
   private:
     Value* value_;
@@ -262,6 +177,7 @@ class maybe_view<Value&> : public ranges::view_interface<maybe_view<Value&>> {
                    : (bool(lhs.value_) == bool(rhs.value_));
     }
 
+
     template <typename F>
     constexpr auto and_then(F&& f) &;
     template <typename F>
@@ -271,7 +187,6 @@ class maybe_view<Value&> : public ranges::view_interface<maybe_view<Value&>> {
     template <typename F>
     constexpr auto and_then(F&& f) const&&;
     template <typename F>
-
     constexpr auto transform(F&& f) &;
     template <typename F>
     constexpr auto transform(F&& f) &&;
@@ -328,6 +243,7 @@ constexpr const Value* maybe_view<Value&>::data() const noexcept {
         return nullptr;
     return std::addressof(*value_);
 }
+
 
 template <typename Value>
 template <typename F>
@@ -434,16 +350,15 @@ maybe_view(Value) -> maybe_view<Value>;
 
 namespace std::ranges {
 template <typename T>
-inline constexpr bool enable_borrowed_range<smd::views::maybe_view<T*>> =
-    true;
+inline constexpr bool enable_borrowed_range<smd::views::maybe_view<T*>> = true;
 
 template <typename T>
-inline constexpr bool enable_borrowed_range<
-    smd::views::maybe_view<std::reference_wrapper<T>>> = true;
+inline constexpr bool
+    enable_borrowed_range<smd::views::maybe_view<std::reference_wrapper<T>>> =
+        true;
 
 template <typename T>
-inline constexpr bool enable_borrowed_range<smd::views::maybe_view<T&>> =
-    true;
+inline constexpr bool enable_borrowed_range<smd::views::maybe_view<T&>> = true;
 
 } // namespace std::ranges
 

--- a/src/smd/views/maybe.h
+++ b/src/smd/views/maybe.h
@@ -7,12 +7,33 @@
 #include <iostream>
 #include <ranges>
 #include <type_traits>
+#include <utility>
 
 #include <smd/views/concepts.h>
-#include <smd/views/movable_box.h>
 
 namespace smd::views {
 namespace ranges = std::ranges;
+
+#if __cpp_lib_forward_like >= 202207L
+template <class T, class U>
+[[nodiscard]] constexpr auto&& forward_like(U&& x) noexcept {
+    constexpr bool is_adding_const =
+        std::is_const_v<std::remove_reference_t<T>>;
+    if constexpr (std::is_lvalue_reference_v<T&&>) {
+        if constexpr (is_adding_const)
+            return std::as_const(x);
+        else
+            return static_cast<U&>(x);
+    } else {
+        if constexpr (is_adding_const)
+            return std::move(std::as_const(x));
+        else
+            return std::move(x);
+    }
+}
+#else
+using std::forward_like;
+#endif
 
 template <typename Value>
 class maybe_view;
@@ -63,36 +84,13 @@ class maybe_view : public ranges::view_interface<maybe_view<Value>> {
     }
 
     template <typename Self, typename F>
-    constexpr auto and_then(this Self&& self, F&& f) {
-        using U =
-            std::invoke_result_t<F,
-                                 decltype(*std::forward<Self>(self).value_)>;
-        static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
-        if (self.value_) {
-            return std::invoke(std::forward<F>(f),
-                               *std::forward<Self>(self).value_);
-        } else {
-            return std::remove_cvref_t<U>();
-        }
-    }
+    constexpr auto and_then(this Self&& self, F&& f);
 
     template <typename Self, typename F>
-    constexpr auto transform(this Self&& self, F&& f) {
-        using U =
-            std::invoke_result_t<F,
-                                 decltype(*std::forward<Self>(self).value_)>;
-        return (self.value_)
-                   ? maybe_view<U>{std::invoke(
-                         std::forward<F>(f), *std::forward<Self>(self).value_)}
-                   : maybe_view<U>{};
-    }
+    constexpr auto transform(this Self&& self, F&& f);
 
     template <typename Self, typename F>
-    constexpr auto or_else(this Self&& self, F&& f) {
-        using U = std::invoke_result_t<F>;
-        static_assert(std::is_same_v<std::remove_cvref_t<U>, maybe_view>);
-        return self.value_ ? std::forward<Self>(self) : std::forward<F>(f)();
-    }
+    constexpr auto or_else(this Self&& self, F&& f);
 };
 
 template <typename Value>
@@ -141,6 +139,43 @@ constexpr const Value* maybe_view<Value>::data() const noexcept {
 }
 
 template <typename Value>
+template <typename Self, typename F>
+constexpr auto maybe_view<Value>::and_then(this Self&& self, F&& f) {
+    using U =
+        std::invoke_result_t<F, decltype(forward_like<Self>(*self.value_))>;
+    static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
+    if (self.value_) {
+        return std::invoke(std::forward<F>(f),
+                           forward_like<Self>(*self.value_));
+    } else {
+        return std::remove_cvref_t<U>();
+    }
+}
+
+template <typename Value>
+template <typename Self, typename F>
+constexpr auto maybe_view<Value>::transform(this Self&& self, F&& f) {
+    using U =
+        std::invoke_result_t<F, decltype(forward_like<Self>(*self.value_))>;
+    return (self.value_)
+               ? maybe_view<U>{std::invoke(std::forward<F>(f),
+                                           forward_like<Self>(*self.value_))}
+               : maybe_view<U>{};
+}
+
+template <typename Value>
+    template <typename Self, typename F>
+    constexpr auto maybe_view<Value>::or_else(this Self&& self, F&& f) {
+        using U = std::invoke_result_t<F>;
+        static_assert(std::is_same_v<std::remove_cvref_t<U>, maybe_view>);
+        return self.value_ ? std::forward<Self>(self) : std::forward<F>(f)();
+    }
+
+/////////////////////
+// maybe_view<T&>
+////////////////////
+
+template <typename Value>
 class maybe_view<Value&> : public ranges::view_interface<maybe_view<Value&>> {
   private:
     Value* value_;
@@ -177,28 +212,19 @@ class maybe_view<Value&> : public ranges::view_interface<maybe_view<Value&>> {
                    : (bool(lhs.value_) == bool(rhs.value_));
     }
 
+    template <typename Self, typename F>
+    constexpr auto and_then(this Self&& self, F&& f);
 
-    template <typename F>
-    constexpr auto and_then(F&& f) &;
-    template <typename F>
-    constexpr auto and_then(F&& f) &&;
-    template <typename F>
-    constexpr auto and_then(F&& f) const&;
-    template <typename F>
-    constexpr auto and_then(F&& f) const&&;
-    template <typename F>
-    constexpr auto transform(F&& f) &;
-    template <typename F>
-    constexpr auto transform(F&& f) &&;
-    template <typename F>
-    constexpr auto transform(F&& f) const&;
-    template <typename F>
-    constexpr auto transform(F&& f) const&&;
-    template <typename F>
+    template <typename Self, typename F>
+    constexpr auto transform(this Self&& self, F&& f);
 
-    constexpr maybe_view or_else(F&& f) &&;
-    template <typename F>
-    constexpr maybe_view or_else(F&& f) const&;
+    template <typename Self, typename F>
+    constexpr maybe_view or_else(this Self&& self, F&& f);
+
+    // template <typename F>
+    // constexpr maybe_view or_else(F&& f) &&;
+    // template <typename F>
+    // constexpr maybe_view or_else(F&& f) const&;
 };
 
 template <typename Value>
@@ -244,103 +270,38 @@ constexpr const Value* maybe_view<Value&>::data() const noexcept {
     return std::addressof(*value_);
 }
 
-
 template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::and_then(F&& f) & {
-    using U = std::invoke_result_t<F, Value&>;
+template <typename Self, typename F>
+constexpr auto maybe_view<Value&>::and_then(this Self&& self, F&& f) {
+    using U =
+        std::invoke_result_t<F, decltype(forward_like<Self>(*self.value_))>;
     static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
-    if (value_) {
-        return std::invoke(std::forward<F>(f), *value_);
+    if (self.value_) {
+        return std::invoke(std::forward<F>(f),
+                           forward_like<Self>(*self.value_));
     } else {
         return std::remove_cvref_t<U>();
     }
 }
 
 template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::and_then(F&& f) && {
-    using U = std::invoke_result_t<F, Value&&>;
-    static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
-    if (value_) {
-        return std::invoke(std::forward<F>(f), std::move(*value_));
-    } else {
-        return std::remove_cvref_t<U>();
-    }
+template <typename Self, typename F>
+constexpr auto maybe_view<Value&>::transform(this Self&& self, F&& f) {
+    using U =
+        std::invoke_result_t<F, decltype(forward_like<Self>(*self.value_))>;
+    return (self.value_)
+               ? maybe_view<U>{std::invoke(std::forward<F>(f),
+                                           forward_like<Self>(*self.value_))}
+               : maybe_view<U>{};
 }
 
 template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::and_then(F&& f) const& {
-    using U = std::invoke_result_t<F, const Value&>;
-    static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
-    if (value_) {
-        return std::invoke(std::forward<F>(f), *value_);
-    } else {
-        return std::remove_cvref_t<U>();
-    }
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::and_then(F&& f) const&& {
-    using U = std::invoke_result_t<F, const Value&&>;
-    static_assert(is_maybe_view_v<std::remove_cvref_t<U>>);
-    if (value_) {
-        return std::invoke(std::forward<F>(f), std::move(*value_));
-    } else {
-        return std::remove_cvref_t<U>();
-    }
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::transform(F&& f) & {
-    using U = std::invoke_result_t<F, Value&>;
-    return (value_) ? maybe_view<U>{std::invoke(std::forward<F>(f), *value_)}
-                    : maybe_view<U>{};
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::transform(F&& f) && {
-    using U = std::invoke_result_t<F, Value&&>;
-    return (value_) ? maybe_view<U>{std::invoke(std::forward<F>(f),
-                                                std::move(*value_))}
-                    : maybe_view<U>{};
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::transform(F&& f) const& {
-    using U = std::invoke_result_t<F, const Value&>;
-    return (value_) ? maybe_view<U>{std::invoke(std::forward<F>(f), *value_)}
-                    : maybe_view<U>{};
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::transform(F&& f) const&& {
-    using U = std::invoke_result_t<F, const Value&&>;
-    return (value_) ? maybe_view<U>{std::invoke(std::forward<F>(f),
-                                                std::move(*value_))}
-                    : maybe_view<U>{};
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::or_else(F&& f) const& -> maybe_view {
+template <typename Self, typename F>
+constexpr maybe_view<Value&> maybe_view<Value&>::or_else(this Self&& self,
+                                                         F&&         f) {
     using U = std::invoke_result_t<F>;
-    static_assert(std::is_same_v<std::remove_cvref_t<U>, maybe_view>);
-    return value_ ? *this : std::forward<F>(f)();
-}
-
-template <typename Value>
-template <typename F>
-constexpr auto maybe_view<Value&>::or_else(F&& f) && -> maybe_view {
-    using U = std::invoke_result_t<F>;
-    static_assert(std::is_same_v<std::remove_cvref_t<U>, maybe_view>);
-    return value_ ? std::move(*this) : std::forward<F>(f)();
+    static_assert(std::is_same_v<std::remove_cvref_t<U>, maybe_view<Value&>>);
+    return self.value_ ? std::forward<Self>(self) : std::forward<F>(f)();
 }
 
 template <typename Value>

--- a/src/smd/views/maybe.t.cpp
+++ b/src/smd/views/maybe.t.cpp
@@ -555,7 +555,7 @@ TEST(MaybeView, MonadicTransformRef) {
     ASSERT_TRUE(!r.empty());
     ASSERT_TRUE(r.size() == 1);
     ASSERT_TRUE(r.data() != nullptr);
-    ASSERT_TRUE(*(r.data()) == 42);
+    ASSERT_EQ(*(r.data()), 42);
     ASSERT_TRUE(!mv.empty());
     ASSERT_TRUE(*(mv.data()) == 40);
 

--- a/targets.mk
+++ b/targets.mk
@@ -70,4 +70,7 @@ realclean: ## Delete the build directory
 env:
 	$(foreach v, $(.VARIABLES), $(info $(v) = $($(v))))
 
+view-maybe.pdf:
+	make -C papers view-maybe.pdf
+
 .PHONY : compile install ctest ctest_ test cmake clean realclean env


### PR DESCRIPTION
Use deducing this to reduce boilerplate. Compiles with gcc-14 and clang-18. Polyfill a local forward_like<T,U>. 